### PR TITLE
Less limiting of gem pin processing in specs

### DIFF
--- a/spec/solargraph/rspec/convention_spec.rb
+++ b/spec/solargraph/rspec/convention_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Solargraph::Rspec::Convention do
   before do
     # For performance reasons, avoid solargraph loading all installed gems' YARDoc and RBS gem pins.
     # If your specs depend on YARDoc or RBS types, add them to the spec/solargraph/rspec/first_party_gem_helpers_spec.rb
-    avoid_gem_yard_and_rbs_pin_generation
+    allow(Solargraph::Rspec::Gems).to receive(:gem_names).and_return(%w[rspec])
   end
 
   it 'generates method for described_class' do

--- a/spec/solargraph/rspec/spec_walker_spec.rb
+++ b/spec/solargraph/rspec/spec_walker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Solargraph::Rspec::SpecWalker do
 
   before do
     # For performance reasons, avoid solargraph loading all installed gems' YARDoc and RBS gem pins.
-    avoid_gem_yard_and_rbs_pin_generation
+    allow(Solargraph::Rspec::Gems).to receive(:gem_names).and_return([])
   end
 
   def parse_expected_let_method(code)

--- a/spec/support/solargraph_helpers.rb
+++ b/spec/support/solargraph_helpers.rb
@@ -92,10 +92,4 @@ module SolargraphHelpers
 
     var_pin
   end
-
-  # For performance reasons, avoid solargraph loading all installed gems' YARDoc and RBS gem pins.
-  # @return [void]
-  def avoid_gem_yard_and_rbs_pin_generation
-    allow(Solargraph::Rspec::Gems).to receive(:gem_names).and_return([])
-  end
 end


### PR DESCRIPTION
This matches a future Solargraph change which seems to be more conservative including gems while resolving constants - see https://github.com/castwide/solargraph/pull/1107 for an example failure.